### PR TITLE
WIP: Add architecture constraints

### DIFF
--- a/webservice/composer.json
+++ b/webservice/composer.json
@@ -100,6 +100,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.64.0",
+        "phpat/phpat": "0.10.18",
         "phpstan/phpstan": "^1.12",
         "phpstan/phpstan-doctrine": "^1.5",
         "phpstan/phpstan-phpunit": "^1.4",

--- a/webservice/composer.lock
+++ b/webservice/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c2284d69847253e031c5d51a28311419",
+    "content-hash": "2c43f92399db950a3b527c76dfef5412",
     "packages": [
         {
             "name": "brick/date-time",
@@ -6388,6 +6388,63 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
+            "name": "phpat/phpat",
+            "version": "0.10.20",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/carlosas/phpat.git",
+                "reference": "55154db9c36d56aaae5de4bcddb7f5a1202f1910"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/carlosas/phpat/zipball/55154db9c36d56aaae5de4bcddb7f5a1202f1910",
+                "reference": "55154db9c36d56aaae5de4bcddb7f5a1202f1910",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^1.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "3.46",
+                "kubawerlos/php-cs-fixer-custom-fixers": "3.18",
+                "phpunit/phpunit": "^9.0 || ^10.0",
+                "vimeo/psalm": "^5.0"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "helpers.php"
+                ],
+                "psr-4": {
+                    "PHPat\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Carlos Alandete Sastre",
+                    "email": "carlos.alandete@gmail.com"
+                }
+            ],
+            "description": "PHP Architecture Tester",
+            "support": {
+                "issues": "https://github.com/carlosas/phpat/issues",
+                "source": "https://github.com/carlosas/phpat/tree/0.10.20"
+            },
+            "time": "2024-11-23T21:56:24+00:00"
+        },
+        {
             "name": "phpstan/phpstan",
             "version": "1.12.12",
             "source": {
@@ -9154,7 +9211,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -9162,6 +9219,6 @@
         "ext-ctype": "*",
         "ext-iconv": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/webservice/phpstan.dist.neon
+++ b/webservice/phpstan.dist.neon
@@ -20,3 +20,21 @@ includes:
 #    - vendor/phpstan/phpstan-doctrine/rules.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-phpunit/rules.neon
+    - vendor/phpat/phpat/extension.neon
+
+services:
+    - class: App\Tests\Architecture\DependenciesBetweenCoreModules
+      tags:
+          - phpat.test
+
+    - class: App\Tests\Architecture\HighLevelArchitecture
+      tags:
+          - phpat.test
+    
+    - class: App\Tests\Architecture\NamingConventions
+      tags:
+          - phpat.test
+
+    - class: App\Tests\Architecture\TestConventions
+      tags:
+          - phpat.test

--- a/webservice/tests/Architecture/DependenciesBetweenCoreModules.php
+++ b/webservice/tests/Architecture/DependenciesBetweenCoreModules.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Tests\Architecture;
+
+use PHPat\Selector\Selector;
+use PHPat\Test\Builder\Rule;
+use PHPat\Test\PHPat;
+
+/**
+ * PHPAT Test Suite called by PHPSTAN
+ *
+ * This test suite defines rules for the relationship between modules in the Core.
+ *
+ * When creating a new module, add a const with the fully qualified namespace
+ * and create a restrictive test method defining which modules it can depend on.
+ */
+final class DependenciesBetweenCoreModules
+{
+    const string APP_CORE_CONTRACT = 'App\Core\Contract';
+    const string APP_CORE_INTEL_PAGE = 'App\Core\IntelPage';
+    const string APP_CORE_MESSAGE_RECIPIENT = 'App\Core\MessageRecipient';
+    const string APP_CORE_SEND_MESSAGE = 'App\Core\SendMessage';
+    const string APP_CORE_TRANSPORT_CONTRACT = 'App\Core\TransportContract';
+
+    public function testSendMessageOnlyDependsOnLowerLevelContracts(): Rule
+    {
+        return $this->moduleCanOnlyDependOn(
+            self::APP_CORE_SEND_MESSAGE,
+            [self::APP_CORE_TRANSPORT_CONTRACT, self::APP_CORE_CONTRACT]
+        );
+    }
+
+    public function testMessageRecipientOnlyDependsOnLowerLevelContracts(): Rule
+    {
+        return $this->moduleCanOnlyDependOn(
+            self::APP_CORE_MESSAGE_RECIPIENT,
+            [self::APP_CORE_TRANSPORT_CONTRACT, self::APP_CORE_CONTRACT]
+        );
+    }
+
+
+    public function testIntelPageOnlyDependsOnLowerLevelContracts(): Rule
+    {
+        return $this->moduleCanOnlyDependOn(
+            self::APP_CORE_INTEL_PAGE,
+            [self::APP_CORE_TRANSPORT_CONTRACT, self::APP_CORE_CONTRACT]
+        );
+    }
+
+    public function testTransportContractOnlyDependsOnLowerLevelContracts(): Rule
+    {
+        return $this->moduleCanOnlyDependOn(
+            self::APP_CORE_TRANSPORT_CONTRACT,
+            []
+        );
+    }
+
+    public function testContractOnlyDependsOnItself(): Rule
+    {
+        return $this->moduleCanOnlyDependOn(
+            self::APP_CORE_CONTRACT,
+            []
+        );
+    }
+
+    public function testContractOnlyContainsInterfaces(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::APP_CORE_CONTRACT))
+            ->shouldBeInterface()
+            ->because('they must not contain implementation');
+    }
+
+    /**
+     * Within the App\Core namespace, a module can only depend on itself and the allowed dependencies.
+     *
+     * @param non-empty-string $module
+     * @param non-empty-string[] $allowedDependencies
+     */
+    private function moduleCanOnlyDependOn(string $module, array $allowedDependencies): Rule
+    {
+        $allowedSelectors = array_map(fn($fqn) => Selector::inNamespace($fqn), $allowedDependencies);
+        return PHPat::rule()
+            ->classes(Selector::inNamespace($module))
+            ->canOnlyDependOn()->classes(
+                Selector::NOT(Selector::inNamespace('App\Core')), // everything outside the core is handled by rules in HighLevelArchitecture.php
+                Selector::inNamespace($module),
+                ...$allowedSelectors,
+
+            )
+            ->because('to increase maintainability');
+    }
+}

--- a/webservice/tests/Architecture/HighLevelArchitecture.php
+++ b/webservice/tests/Architecture/HighLevelArchitecture.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Tests\Architecture;
+
+use PHPat\Selector\Selector;
+use PHPat\Test\Builder\Rule;
+use PHPat\Test\PHPat;
+
+/**
+ * PHPAT Test Suite called by PHPSTAN
+ *
+ * This test suite defines rules concerning the general namespace structure.
+ */
+final class HighLevelArchitecture
+{
+    public function testCoreOnlyDependsOnItselfAndNamedExceptions(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace('App\Core'))
+            ->canOnlyDependOn()->classes(
+                Selector::inNamespace('App\Core'),
+                // ORM Mapping
+                Selector::inNamespace('Doctrine\ORM'),
+                Selector::classname('Symfony\Bridge\Doctrine\Types\UlidType'),
+                // Value Objects & Co
+                Selector::inNamespace('Brick\DateTime'),
+                Selector::classname('Symfony\Component\Uid\Ulid'),
+                Selector::inNamespace('Doctrine\Common\Collections'),
+                // PHP
+                Selector::classname(\BackedEnum::class),
+                Selector::classname(\Traversable::class),
+                Selector::classname('/^[A-Za-z]*Exception$/', true), // Global exceptions
+            )
+            ->because('core should not be polluted by view or dependency specific implementations.');
+    }
+
+    public function testInfrastructureDoesNotDependOnView(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace('App\Infrastructure'))
+            ->canOnlyDependOn()->classes(
+                Selector::inNamespace('App\Core'),
+                Selector::inNamespace('App\Infrastructure'),
+                Selector::NOT(Selector::inNamespace('App\View'))
+            )
+            ->because('should not be view specific.');
+    }
+
+    public function testOutsideCodeDoesNotDependOnApplicationServices(): Rule
+    {
+        return PHPat::rule()
+            ->classes(
+                Selector::inNamespace('App\Infrastructure'),
+                Selector::inNamespace('App\Core'),
+                Selector::inNamespace('App\View'),
+            )
+            ->canOnlyDependOn()->classes(
+                Selector::NOT(Selector::inNamespace('/App\Core\[A-Za-z0-9]+\Application/', true))
+            )
+            ->because('should depend on Port interfaces');
+    }
+
+    public function testModuleCodeIsSeparatedIntoChildNamespaces(): Rule
+    {
+        return PHPat::rule()
+            ->classes(
+                Selector::inNamespace('/App\Core\[A-Za-z0-9]+$/', true),
+            )
+            ->shouldNotExist()
+            ->because('should me moved to a child-namespace');
+    }
+}

--- a/webservice/tests/Architecture/NamingConventions.php
+++ b/webservice/tests/Architecture/NamingConventions.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Tests\Architecture;
+
+use PHPat\Selector\Selector;
+use PHPat\Test\Builder\Rule;
+use PHPat\Test\PHPat;
+
+/**
+ * PHPAT Test Suite called by PHPSTAN
+ *
+ * This test suite defines naming conventions for this project
+ */
+final class NamingConventions
+{
+    public function testControllersHaveSuffix(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::appliesAttribute('Symfony\Component\Routing\Attribute\Route'))
+            ->shouldBeNamed('/\w+Controller$/', regex: true)
+            ->because('controllers must use suffix.');
+    }
+
+    public function testFormsHaveSuffix(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::extends('Symfony\Component\Form\AbstractType'))
+            ->shouldBeNamed('/\w+Form$/', regex: true)
+            ->because('form types must use `Form` suffix.');
+    }
+
+    public function testEventsHaveNoSuffix(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace('App\Core\**\Event\**'))
+            ->shouldBeNamed('/.*(?<!Event)$/', regex: true)
+            ->because('events must not use suffix.');
+    }
+}

--- a/webservice/tests/Architecture/TestConventions.php
+++ b/webservice/tests/Architecture/TestConventions.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Tests\Architecture;
+
+use PHPat\Selector\Selector;
+use PHPat\Test\Builder\Rule;
+use PHPat\Test\PHPat;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Metadata\Covers;
+use PHPUnit\Metadata\CoversClass;
+use PHPUnit\Metadata\CoversFunction;
+use PHPUnit\Metadata\CoversMethod;
+use PHPUnit\Metadata\CoversNothing;
+
+/**
+ * PHPAT Test Suite called by PHPSTAN
+ *
+ * This test suite defines naming conventions for this project
+ */
+final class TestConventions
+{
+    public function testTestSuitesAreFinal(): Rule
+    {
+        return $this->allTestSuites()
+            ->shouldBeFinal()
+            ->because('Test classes will never be extended');
+    }
+
+    public function testTestHaveGroupAttribute(): Rule
+    {
+        return $this->allTestSuites()
+            ->shouldApplyAttribute()->classes(Selector::classname(Group::class))
+            ->because('Tests must be assigned to at least one group (e.g. unit, integration)');
+    }
+
+    public function testTestSuitesShouldHaveTestSuffix(): Rule
+    {
+        return $this->allTestSuites()
+            ->shouldBeNamed('/^App\\Tests\\[\\A-Za-z0-9]+Test$/', true)
+            ->because('Tests must be assigned to at least one group (e.g. unit, integration)');
+    }
+
+    /* public function testTestSuitesShouldHaveCoversAnnotation(): Rule
+    {
+        // TODO requires latest phpat, which is only available after phpstan 2.0 update
+        return $this->allTestSuites()
+            ->shouldApplyAttribute()->classes(
+                Selector::classname(Covers::class),
+                Selector::classname(CoversClass::class),
+                Selector::classname(CoversNothing::class),
+                Selector::classname(CoversMethod::class),
+                Selector::classname(CoversFunction::class),
+            )
+            ->because('test suites should cover only explicitly tested code');
+    } */
+
+    public function allTestSuites(): \PHPat\Test\Builder\SubjectExcludeOrAssertionStep
+    {
+        // TODO Selector::ALL
+        return PHPat::rule()
+            ->classes(
+                /*Selector::AND(
+                    Selector::classname('/^App\\Tests\\[\\A-Za-z0-9]+Test$/]'),
+                    Selector::NOT(Selector::inNamespace('App\Tests\Architecture'))
+                ),*/
+                Selector::inNamespace('App\Tests'),
+                Selector::extends(TestSuite::class),
+                Selector::NOT(Selector::isAbstract())
+            );
+    }
+}


### PR DESCRIPTION
Here a proposal to add architecture checks using https://www.phpat.dev/, executed as phpstan extension.

Checks are seperated in:

- HighLevelArchitecture, some basic checks, basically on the structure of our namespaces
- CoreDomainLayers, limiting which components inside core can depend on others
- NamingConventions to enforce a pattern language

Currently checks are limited as component names are not finalised. Any checks besides those in the core that should be established?

- [ ] Add phpat to composer.lock file